### PR TITLE
JAV-227 use class method instead of detail implementation

### DIFF
--- a/saga-core/src/main/java/io/servicecomb/saga/core/EmbeddedEventStore.java
+++ b/saga-core/src/main/java/io/servicecomb/saga/core/EmbeddedEventStore.java
@@ -30,7 +30,7 @@ class EmbeddedEventStore implements EventStore {
   @Override
   public void offer(SagaEvent sagaEvent) {
     events.offer(sagaEvent);
-    log.info("Added event id={}, type={}", sagaEvent.id(), sagaEvent.getClass().getSimpleName());
+    log.info("Added event id={}, type={}", sagaEvent.id(), sagaEvent.description());
   }
 
   @Override


### PR DESCRIPTION
method `description` has already implemented the functionality of `getClass().getSimpleName()`, just call the class method directly.